### PR TITLE
updates

### DIFF
--- a/mfile
+++ b/mfile
@@ -2,7 +2,7 @@
   "package": "ThreshKeepalive",
   "title": "Send a keepalive message every 150,000,000,000,000 picoseconds",
   "description": "Threshold Keepalive package for Mudlet",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "Gesslar@ThresholdRPG",
   "icon": "griffon-right.jpg",
   "dependencies": "",


### PR DESCRIPTION
### TL;DR

Bump ThreshKeepalive package version from 1.6.1 to 1.6.2.

### What changed?

Updated the version number in the package metadata from 1.6.1 to 1.6.2.

### How to test?

1. Install the updated package in Mudlet
2. Verify that the package information shows version 1.6.2
3. Confirm that the keepalive functionality continues to work as expected

### Why make this change?

Version bump to reflect recent changes or fixes in the ThreshKeepalive package.